### PR TITLE
Fix for py3

### DIFF
--- a/ncbi_genome_download/__main__.py
+++ b/ncbi_genome_download/__main__.py
@@ -15,7 +15,7 @@ def main():
                         help='NCBI section to download')
     parser.add_argument('-F', '--format',
                         dest='file_format', default='genbank',
-                        choices=['all'] + ncbi_genome_download.format_name_map.keys(),
+                        choices=['all'] + list(ncbi_genome_download.format_name_map.keys()),
                         help='Which format to download (default: genbank)')
     parser.add_argument('-o', '--output-folder',
                         dest='output', default=os.getcwd(),


### PR DESCRIPTION
The latest version is not working in py3 due to the new format argument concatenate different types.. Specifying the key as a list should fix this issue.