### PR TITLE
Download genomes based on NCBI taxonomy IDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,17 @@ ncbi-genome-download --genus Streptomyces bacteria
 ```
 **Note**: This is a simple string match on the organism name provided by NCBI only.
 
+To download bacterial RefSeq genomes based on their NCBI species taxonomy ID, run:
+```
+ncbi-genome-download --species-taxid 562 bacteria
+```
+**Note**: The above command will download all RefSeq genomes belonging to _Escherichia coli_.
+
+To download a specific bacterial RefSeq genomes based on its NCBI taxonomy ID, run:
+```
+ncbi-genome-download --taxid 511145 bacteria
+```
+**Note**: The above command will download the RefSeq genome belonging to _Escherichia coli str. K-12 substr. MG1655_.
 
 To get an overview of all options, run
 ```

--- a/ncbi_genome_download/__main__.py
+++ b/ncbi_genome_download/__main__.py
@@ -26,6 +26,9 @@ def main():
     parser.add_argument('-g', '--genus',
                         dest='genus', default='',
                         help='Only download sequences of the provided genus. (default: unset, download all)')
+    parser.add_argument('-t', '--taxid',
+                        dest='taxid',
+                        help='Only download sequences of the provided NCBI taxonomy ID. (default: unset, download all)')
     parser.add_argument('-o', '--output-folder',
                         dest='output', default=os.getcwd(),
                         help='Create output hierarchy in specified folder (default: current directory)')

--- a/ncbi_genome_download/__main__.py
+++ b/ncbi_genome_download/__main__.py
@@ -26,6 +26,9 @@ def main():
     parser.add_argument('-g', '--genus',
                         dest='genus', default='',
                         help='Only download sequences of the provided genus. (default: unset, download all)')
+    parser.add_argument('-T', '--species-taxid',
+                        dest='species_taxid',
+                        help='Only download sequences of the provided species NCBI taxonomy ID. (default: unset, download all)')
     parser.add_argument('-t', '--taxid',
                         dest='taxid',
                         help='Only download sequences of the provided NCBI taxonomy ID. (default: unset, download all)')

--- a/ncbi_genome_download/core.py
+++ b/ncbi_genome_download/core.py
@@ -44,14 +44,17 @@ def download(args):
     if args.domain == 'all':
         for domain in SUPPORTED_DOMAINS:
             _download(args.section, domain, args.uri, args.output, args.file_format,
-                      args.assembly_level, args.genus, args.taxid, args.parallel)
+                      args.assembly_level, args.genus, args.species_taxid,
+                      args.taxid, args.parallel)
     else:
         _download(args.section, args.domain, args.uri, args.output, args.file_format,
-                  args.assembly_level, args.genus, args.taxid, args.parallel)
+                  args.assembly_level, args.genus, args.species_taxid,
+                  args.taxid, args.parallel)
 
 
 # pylint: disable=too-many-arguments
-def _download(section, domain, uri, output, file_format, assembly_level, genus='', taxid=None, parallel=1):
+def _download(section, domain, uri, output, file_format, assembly_level, genus='',
+              species_taxid=None, taxid=None, parallel=1):
     '''Download a specified domain form a section'''
     summary_file = get_summary(section, domain, uri)
     entries = parse_summary(summary_file)
@@ -61,9 +64,13 @@ def _download(section, domain, uri, output, file_format, assembly_level, genus='
             logging.debug('Organism name %r does not start with %r as requested, skipping',
                           entry['organism_name'], genus)
             continue
+        if species_taxid is not None and entry['species_taxid'] != species_taxid:
+            logging.debug('Species TaxID %r different from the one provided %r, skipping',
+                          entry['species_taxid'], species_taxid)
+            continue
         if taxid is not None and entry['taxid'] != taxid:
-            logging.debug('Organism TaxID %r different from the onje provided %r, skipping',
-                          entry['species_taxid'], taxid)
+            logging.debug('Organism TaxID %r different from the one provided %r, skipping',
+                          entry['taxid'], taxid)
             continue
         if assembly_level != 'all' and entry['assembly_level'] != ASSEMBLY_LEVEL_MAP[assembly_level]:
             logging.debug('Skipping entry with assembly level %r', entry['assembly_level'])

--- a/ncbi_genome_download/core.py
+++ b/ncbi_genome_download/core.py
@@ -44,14 +44,14 @@ def download(args):
     if args.domain == 'all':
         for domain in SUPPORTED_DOMAINS:
             _download(args.section, domain, args.uri, args.output, args.file_format,
-                      args.assembly_level, args.genus, args.parallel)
+                      args.assembly_level, args.genus, args.taxid, args.parallel)
     else:
         _download(args.section, args.domain, args.uri, args.output, args.file_format,
-                  args.assembly_level, args.genus, args.parallel)
+                  args.assembly_level, args.genus, args.taxid, args.parallel)
 
 
 # pylint: disable=too-many-arguments
-def _download(section, domain, uri, output, file_format, assembly_level, genus='', parallel=1):
+def _download(section, domain, uri, output, file_format, assembly_level, genus='', taxid=None, parallel=1):
     '''Download a specified domain form a section'''
     summary_file = get_summary(section, domain, uri)
     entries = parse_summary(summary_file)
@@ -60,6 +60,10 @@ def _download(section, domain, uri, output, file_format, assembly_level, genus='
         if not entry['organism_name'].startswith(genus.capitalize()):
             logging.debug('Organism name %r does not start with %r as requested, skipping',
                           entry['organism_name'], genus)
+            continue
+        if taxid is not None and entry['taxid'] != taxid:
+            logging.debug('Organism TaxID %r different from the onje provided %r, skipping',
+                          entry['species_taxid'], taxid)
             continue
         if assembly_level != 'all' and entry['assembly_level'] != ASSEMBLY_LEVEL_MAP[assembly_level]:
             logging.debug('Skipping entry with assembly level %r', entry['assembly_level'])

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -141,6 +141,36 @@ def test__download_genus_lowercase(monkeypatch, mocker, req):
     assert core.download_entry.call_args_list[0][0][0]['organism_name'] == 'Azorhizobium caulinodans ORS 571'
 
 
+def test__download_taxid(monkeypatch, mocker, req):
+    summary_contents = open(_get_file('partial_summary.txt'), 'r').read()
+    req.get('http://ftp.ncbi.nih.gov/genomes/refseq/bacteria/assembly_summary.txt',
+            text=summary_contents)
+    mocker.spy(core, 'get_summary')
+    mocker.spy(core, 'parse_summary')
+    mocker.patch('ncbi_genome_download.core.download_entry')
+    core._download('refseq', 'bacteria', core.NCBI_URI, '/tmp/fake', 'genbank', 'all', '', None, '438753')
+    assert core.get_summary.call_count == 1
+    assert core.parse_summary.call_count == 1
+    assert core.download_entry.call_count == 1
+    # Many nested tuples in call_args_list, no kidding.
+    assert core.download_entry.call_args_list[0][0][0]['organism_name'] == 'Azorhizobium caulinodans ORS 571'
+
+
+def test__download_species_taxid(monkeypatch, mocker, req):
+    summary_contents = open(_get_file('partial_summary.txt'), 'r').read()
+    req.get('http://ftp.ncbi.nih.gov/genomes/refseq/bacteria/assembly_summary.txt',
+            text=summary_contents)
+    mocker.spy(core, 'get_summary')
+    mocker.spy(core, 'parse_summary')
+    mocker.patch('ncbi_genome_download.core.download_entry')
+    core._download('refseq', 'bacteria', core.NCBI_URI, '/tmp/fake', 'genbank', 'all', '', '7')
+    assert core.get_summary.call_count == 1
+    assert core.parse_summary.call_count == 1
+    assert core.download_entry.call_count == 1
+    # Many nested tuples in call_args_list, no kidding.
+    assert core.download_entry.call_args_list[0][0][0]['organism_name'] == 'Azorhizobium caulinodans ORS 571'
+
+
 def test_get_summary(req):
     req.get('http://ftp.ncbi.nih.gov/genomes/refseq/bacteria/assembly_summary.txt', text='test')
     ret = core.get_summary('refseq', 'bacteria', core.NCBI_URI)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -22,10 +22,10 @@ def test_download_one(monkeypatch, mocker):
     monkeypatch.setattr(core, '_download', _download_mock)
     fake_args = Namespace(section='refseq', domain='bacteria', uri=core.NCBI_URI,
                           output='/tmp/fake', file_format='genbank', assembly_level='all',
-                          genus='', parallel=1)
+                          genus='', species_taxid=None, taxid= None, parallel=1)
     core.download(fake_args)
     _download_mock.assert_called_with('refseq', 'bacteria', core.NCBI_URI, '/tmp/fake',
-                                      'genbank', 'all', '', 1)
+                                      'genbank', 'all', '', None, None, 1)
 
 
 def test_download_all(monkeypatch, mocker):
@@ -33,7 +33,7 @@ def test_download_all(monkeypatch, mocker):
     monkeypatch.setattr(core, '_download', _download_mock)
     fake_args = Namespace(section='refseq', domain='all', uri=core.NCBI_URI,
                           output='/tmp/fake', file_format='genbank', assembly_level='all',
-                          genus='', parallel=1)
+                          genus='', species_taxid=None, taxid=None, parallel=1)
     core.download(fake_args)
     assert _download_mock.call_count == len(core.SUPPORTED_DOMAINS)
 


### PR DESCRIPTION
Hi,

first of all, many thanks for this very useful piece of software. I have added two options to use the NCBI taxonomy IDs as filters instead of Genus/Species name:

* Species taxonomy ID to download all the members of a particular species (e.g. 562 for all E. coli)
* Taxonomy ID of a particular strain to download a specific genome (e.g. 511145 for "Escherichia coli str. K-12 substr. MG1655")

No tests are included for the moment, but I would be happy to do so if you would like to include this functionality.

Best,
Marco