### PR TITLE
Download XXX_assembly_report.txt and XXX_assembly_stats.txt

### DIFF
--- a/ncbi_genome_download/core.py
+++ b/ncbi_genome_download/core.py
@@ -98,7 +98,7 @@ class EMap(Enum):
 
 class EFormats(EMap):
     # only needed in Python 2
-    __order__ = 'GENBANK FASTA FEATURES GFF PROTFASTA GENREPT WGS CDSFASTA RNAFASTA'
+    __order__ = 'GENBANK FASTA FEATURES GFF PROTFASTA GENREPT WGS CDSFASTA RNAFASTA ASSEMBLYREPORT ASSEMBLYSTATS'
     GENBANK = ('genbank', '_genomic.gbff.gz')
     FASTA = ('fasta', '_genomic.fna.gz')
     FEATURES = ('features', '_feature_table.txt.gz')
@@ -108,6 +108,8 @@ class EFormats(EMap):
     WGS = ('wgs', '_wgsmaster.gbff.gz')
     CDSFASTA = ('cds-fasta', '_cds_from_genomic.fna.gz')
     RNAFASTA = ('rna-fasta', '_rna_from_genomic.fna.gz')
+    ASSEMBLYREPORT = ('assembly-report', '_assembly_report.txt')
+    ASSEMBLYSTATS = ('assembly-stats', '_assembly_stats.txt')
 
 
 class EAssemblyLevels(EMap):


### PR DESCRIPTION
These two simple small plain text files provided on the NCBI site include some simple easy-to-parse metadata as well as a table about the assembly. I am assuming they are always present.

We were pondering where best to get the taxon number for a ``XXX_genomic.fna.gz`` file, where either of these text files would work (eg ``grep "^# Taxid:" *.txt``) but your handy tool did not fetch them.

Note that as written they will now be included by ``-f all`` so this would be a behaviour change, however the default is still ``-f genbank`` so many users will not be impacted.