### PR TITLE
Use strict bash mode in publish.sh

### DIFF
--- a/publish.sh
+++ b/publish.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euo pipefail
 
 PANDOC=pandoc
 


### PR DESCRIPTION
This will ensure that if ``pandoc`` is missing or fails that the upload to PyPI is aborted.

Otherwise it would proceed but use ``README.md`` rather than ``README.rst`` for the long description, which would not render nicely on PyPI which expects the text to be in reStructuredText markup.

e.g. https://pypi.python.org/pypi/ncbi-genome-download/0.2.0
vs https://pypi.python.org/pypi/ncbi-genome-download/0.2.1

(Would you instead consider simply having ``README.rst`` only, perhaps checked automatically with ``restructuredtext-lint``?)