### PR TITLE
Option to save assembly data to tab-delimited file

### DIFF
--- a/ncbi-genome-download-runner.py
+++ b/ncbi-genome-download-runner.py
@@ -1,0 +1,10 @@
+#!/usr/bin/env python3
+"""
+Convenience wrapper for running ncbi-genome-download directly from source tree.
+"""
+
+from ncbi_genome_download.__main__ import main
+
+if __name__ == '__main__':
+    main()
+

--- a/ncbi_genome_download/__main__.py
+++ b/ncbi_genome_download/__main__.py
@@ -56,6 +56,8 @@ def main():
                         default=0,
                         help='Retry download %(metavar)s times when connection to NCBI fails ('
                              'default: %(default)s)')
+    parser.add_argument('-m', '--metadata-table', type=str,
+                        help='Save tab-delimited file with genome metadata')
     parser.add_argument('-v', '--verbose', action='store_true',
                         help='increase output verbosity')
     parser.add_argument('-d', '--debug', action='store_true',


### PR DESCRIPTION
Hi Kai!

I forked ncbi-genome-download to make two little changes:

1. Made a runner script as described [in this blog post](https://gehrcke.de/2014/02/distributing-a-python-command-line-application/) to allow clone-and-run (without installation).
2. New option `--metadata-table` which creates a tab-delimited file with the information from the summary file.

Go ahead and delete this PR if you don't think it's appropriate for the main repo - I won't be offended :smile: Just thought I'd give you the option!

Ryan