### PR TITLE
Allow passing lists of arguments

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -12,3 +12,6 @@ pipeline:
     image: plugins/slack
     channel: tools
     secrets: [ slack_webhook ]
+    when:
+      status: [ success, failure ]
+      event: push

--- a/Makefile
+++ b/Makefile
@@ -3,3 +3,6 @@ unit:
 
 coverage:
 	py.test --cov=ncbi_genome_download --cov-report term-missing --cov-report html
+
+lint:
+	pylint --disable=C,I,fixme ncbi_genome_download

--- a/README.md
+++ b/README.md
@@ -48,6 +48,11 @@ To download all bacterial RefSeq genomes in GenBank format from NCBI, run the fo
 ncbi-genome-download bacteria
 ```
 
+Downloading multiple groups is also possible:
+```
+ncbi-genome-download bacteria,viral
+```
+
 If you're on a reasonably fast connection, you might want to try running multiple downloads in parallel:
 ```
 ncbi-genome-download bacteria --parallel 4
@@ -62,6 +67,12 @@ ncbi-genome-download --section genbank fungi
 To download all viral RefSeq genomes in FASTA format, run:
 ```
 ncbi-genome-download --format fasta viral
+```
+
+It is possible to download multiple formats by supplying a list of formats or simply download all formats:
+```
+ncbi-genome-download --format fasta,assembly-report viral
+ncbi-genome-download --format all viral
 ```
 
 To download only completed bacterial RefSeq genomes in GenBank format, run:
@@ -87,6 +98,11 @@ ncbi-genome-download --genus "Streptomyces coelicolor" bacteria
 **Note**: The quotes are important. Again, this is a simple string match on the organism
 name provided by the NCBI.
 
+Multiple genera is also possible:
+```
+ncbi-genome-download --genus "Streptomyces coelicolor,Escherichia coli" bacteria
+```
+
 To download bacterial RefSeq genomes based on their NCBI species taxonomy ID, run:
 ```
 ncbi-genome-download --species-taxid 562 bacteria
@@ -99,6 +115,11 @@ ncbi-genome-download --taxid 511145 bacteria
 ```
 **Note**: The above command will download the RefSeq genome belonging to _Escherichia coli str. K-12 substr. MG1655_.
 
+It is also possible to download multiple species taxids or taxids by supplying the numbers in a comma-separated list:
+```
+ncbi-genome-download --taxid 9606,9685 --assembly-level chromosome vertebrate_mammalian
+```
+**Note**: The above command will download the reference genomes for cat and human.
 
 It is possible to also create a human-readable directory structure in parallel to mirroring
 the layout used by NCBI:

--- a/ncbi_genome_download/__init__.py
+++ b/ncbi_genome_download/__init__.py
@@ -1,17 +1,21 @@
 """Download genome files from the NCBI"""
 from .core import (
+    args_download,
     download,
     SUPPORTED_TAXONOMIC_GROUPS,
     EFormats,
     EAssemblyLevels,
-    EDefaults
+    EDefaults,
+    argument_parser
 )
 
 __version__ = '0.2.5'
 __all__ = [
     'download',
+    'args_download',
     'SUPPORTED_TAXONOMIC_GROUPS',
     'EFormats',
     'EAssemblyLevels',
-    'EDefaults'
+    'EDefaults',
+    'argument_parser'
 ]

--- a/ncbi_genome_download/__main__.py
+++ b/ncbi_genome_download/__main__.py
@@ -1,70 +1,12 @@
 """Command line handling for ncbi-genome-download"""
-import argparse
 import logging
-
+from ncbi_genome_download import args_download
+from ncbi_genome_download import argument_parser
 from ncbi_genome_download import __version__
-from ncbi_genome_download import download
-from ncbi_genome_download import EDefaults as dflt
-
 
 def main():
     """Build and parse command line"""
-    parser = argparse.ArgumentParser()
-    parser.add_argument('group',
-                        choices=dflt.TAXONOMIC_GROUPS.choices,
-                        default=dflt.TAXONOMIC_GROUPS.default,
-                        help='The NCBI taxonomic group to download (default: %(default)s)')
-    parser.add_argument('-s', '--section', dest='section',
-                        choices=dflt.SECTIONS.choices,
-                        default=dflt.SECTIONS.default,
-                        help='NCBI section to download (default: %(default)s)')
-    parser.add_argument('-F', '--format', dest='file_format',
-                        choices=dflt.FORMATS.choices,
-                        default=dflt.FORMATS.default,
-                        help='Which format to download (default: %(default)s)')
-    parser.add_argument('-l', '--assembly-level', dest='assembly_level',
-                        choices=dflt.ASSEMBLY_LEVELS.choices,
-                        default=dflt.ASSEMBLY_LEVELS.default,
-                        help='Assembly level of genomes to download (default: %(default)s)')
-    parser.add_argument('-g', '--genus', dest='genus',
-                        default=dflt.GENUS.default,
-                        help='Only download sequences of the provided genus. (default: %(default)s)')
-    parser.add_argument('-T', '--species-taxid', dest='species_taxid',
-                        default=dflt.SPECIES_TAXID.default,
-                        help='Only download sequences of the provided species NCBI taxonomy ID. '
-                             '(default: %(default)s)')
-    parser.add_argument('-t', '--taxid', dest='taxid',
-                        default=dflt.TAXID.default,
-                        help='Only download sequences of the provided NCBI taxonomy ID. ('
-                             'default: %(default)s)')
-    parser.add_argument('-R', '--refseq-category', dest='refseq_category',
-                        choices=dflt.REFSEQ_CATEGORIES.choices,
-                        default=dflt.REFSEQ_CATEGORIES.default,
-                        help='Only download sequences of the provided refseq category (default: %(default)s)')
-    parser.add_argument('-o', '--output-folder', dest='output',
-                        default=dflt.OUTPUT.default,
-                        help='Create output hierarchy in specified folder (default: %(default)s)')
-    parser.add_argument('-H', '--human-readable', dest='human_readable', action='store_true',
-                        help='Create links in human-readable hierarchy (might fail on Windows)')
-    parser.add_argument('-u', '--uri', dest='uri',
-                        default=dflt.URI.default,
-                        help='NCBI base URI to use (default: %(default)s)')
-    parser.add_argument('-p', '--parallel', dest='parallel', type=int, metavar="N",
-                        default=dflt.NB_PROCESSES.default,
-                        help='Run %(metavar)s downloads in parallel (default: %(default)s)')
-    parser.add_argument('-r', '--retries', dest='retries', type=int, metavar="N",
-                        default=0,
-                        help='Retry download %(metavar)s times when connection to NCBI fails ('
-                             'default: %(default)s)')
-    parser.add_argument('-m', '--metadata-table', type=str,
-                        help='Save tab-delimited file with genome metadata')
-    parser.add_argument('-v', '--verbose', action='store_true',
-                        help='increase output verbosity')
-    parser.add_argument('-d', '--debug', action='store_true',
-                        help='print debugging information')
-    parser.add_argument('-V', '--version', action='version', version=__version__,
-                        help='print version information')
-
+    parser = argument_parser(version=__version__)
     args = parser.parse_args()
 
     if args.debug:
@@ -76,18 +18,15 @@ def main():
 
     logging.basicConfig(format='%(levelname)s: %(message)s', level=log_level)
 
-    kwargs = vars(args)
-    del kwargs['debug']
-    del kwargs['verbose']
-    max_retries = kwargs.pop('retries')  # Default value is set in parser argument
+    max_retries = args.retries
     attempts = 0
-    ret = download(**kwargs)
+    ret = args_download(args)
     while ret == 75 and attempts < max_retries:
         attempts += 1
         logging.error(
             'Downloading from NCBI failed due to a connection error, retrying. Retries so far: %s',
             attempts)
-        ret = download(**kwargs)
+        ret = args_download(args)
 
     return ret
 


### PR DESCRIPTION
Fixes #52 

First of all. Thanks for this nice program. The `--retries` flag is a life saver and so is the checking if the file is already present before downloading it. Centrifuge-download does not have these two functions which makes it a pain to use in pipelines.

On the other hand centrifuge-download has the option to download multiple taxids (`-t 9606,9685`) and some other stuff in the same way.

Since this was missing from this program I implemented it. Solving #52 along the way. To do this I removed the parsed args to `kwargs` conversion as it was redundant and the `args` object is more powerful and versatile.

~We should probably add some tests for this. The testing framework for this program is not quite clear to me. Can somebody help with this?~ EDIT: Found the tests. Will be updating.