### PR TITLE
add support for *rna.fna.gz file download

### DIFF
--- a/ncbi_genome_download/config.py
+++ b/ncbi_genome_download/config.py
@@ -28,6 +28,7 @@ class NgdConfig(object):
         ('genpept', '_protein.gpff.gz'),
         ('wgs', '_wgsmaster.gbff.gz'),
         ('cds-fasta', '_cds_from_genomic.fna.gz'),
+        ('rna-fna', '_rna.fna.gz'),
         ('rna-fasta', '_rna_from_genomic.fna.gz'),
         ('assembly-report', '_assembly_report.txt'),
         ('assembly-stats', '_assembly_stats.txt'),

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -685,6 +685,18 @@ def test_download_file_rna_fasta(req, tmpdir):
 
     assert core.worker(core.download_file_job(entry, str(dl_dir), checksums, 'rna-fasta'))
 
+def test_download_file_rna_fna(req, tmpdir):
+    entry = {'ftp_path': 'ftp://fake/path'}
+    fake_file = tmpdir.join('fake_rna.fna.gz')
+    fake_file.write('foo')
+    assert fake_file.check()
+    checksum = core.md5sum(str(fake_file))
+    checksums = [{'checksum': checksum, 'file': fake_file.basename}]
+    dl_dir = tmpdir.mkdir('download')
+    req.get('https://fake/path/fake_rna.fna.gz', text=fake_file.read())
+
+    assert core.worker(core.download_file_job(entry, str(dl_dir), checksums, 'rna-fna'))
+
 
 def test_download_file_symlink_path(req, tmpdir):
     entry = {'ftp_path': 'ftp://fake/path'}


### PR DESCRIPTION
Enable download of *_rna.fna.gz files.

File info from [genbank README:](ftp://ftp.ncbi.nlm.nih.gov/genomes/genbank/README.txt)

   *  ***_rna.fna.gz:**  FASTA format of accessioned RNA products annotated on the genome 
       assembly; Provided for RefSeq assemblies as relevant (Note, RNA and mRNA 
       products are not instantiated as a separate accessioned record in GenBank
       but are provided for some RefSeq genomes, most notably the eukaryotes.)
       The FASTA title is provided as sequence accession.version plus description.

  *  ***_rna_from_genomic.fna.gz**:  FASTA format of the nucleotide sequences corresponding to all RNA features annotated on the assembly, based on the genome sequence. See 
       the "Description of files" section below for details of the file format.

ftp://ftp.ncbi.nlm.nih.gov/genomes/genbank/README.txt