### PR TITLE
bug fixes & added features for gimme_taxa.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,22 +196,27 @@ file to pass in to it. It utilises the `ete3` toolkit, so refer to their site to
 if it's not already satisfied.
 
 You can query the database using a particular TaxID, or a scientific name. The primary function of the
-script is to return all the child taxa of the specified parent taxa. If specified with `-v` verbose
-flags however, the script will also print out some information about the lineages etc.
+script is to return all the child taxa of the specified parent taxa. The script has various options
+for what information is written in the output. 
 
 A basic invocation may look like:
 
 ```
-# Fetch all descendent taxa for Escherichia:
-python gimme_taxa.py -v -o ~/mytaxafile.txt -t 561
+# Fetch all descendent taxa for Escherichia (taxid 561):
+python gimme_taxa.py -o ~/mytaxafile.txt 561
 
-alternatively
+# Alternatively, just provide the taxon name
+python gimme_taxa.py -o all_descendent_taxids.txt Escherichia
 
-python gimme_taxa.py -v -o ~/mytaxafile.txt -n Escherichia
+# You can provide multiple taxids and/or names
+python gimme_taxa.py -o all_descendent_taxids.txt 561,Methanobrevibacter
 ```
 
-On first use, a small sqlite database will be created in your home directory. In future this can be
-updated by providing the `--update` flag.
+On first use, a small sqlite database will be created in your home directory
+by default (change the location with the `--database` flag). You can update this database
+by using the `--update` flag. Note that if the database is not in your home directory,
+you must specify it with `--database` or a new database will be created in your home
+directory.
 
 To see all help:
 ```

--- a/contrib/gimme_taxa.py
+++ b/contrib/gimme_taxa.py
@@ -1,3 +1,6 @@
+#!/usr/bin/env python
+from __future__ import print_function
+
 """
 Perform various queries and tasks with the NCBI taxonomy database,
 via the ETE3 toolkit.
@@ -17,26 +20,20 @@ TODO:
   - Allow users to specify a different directory for the tax_dump
 """
 
-__author__ = "Joe R. J. Healey"
-__version__ = "1.0"
+__author__ = "Joe R. J. Healey; Nick Youngblut"
+__version__ = "1.1"
 __title__ = "gimme_taxa"
 __license__ = "Apache2.0"
 __author_email__ = "J.R.J.Healey@warwick.ac.uk"
 
 
 # Check script compatibilities and module requirements
-
 import sys
-# Some logic for the future in case removing py2.7 support
-#       if sys.version_info[0] is not 3 and sys.version_info[2] is not 6:
-#               raise Exception("This script requires python3.6.0+ - Currently running: %s.%s.%s" % (
-#                               sys.version_info[0], sys.version_info[1], sys.version_info[2]))
-
+import argparse
 try:
-	from ete3 import NCBITaxa
+    from ete3 import NCBITaxa
 except ImportError:
-	print(
-"""
+    msg = """
 The ete3 import failed, the module doesn't appear to be installed
 (at least in the PYTHONPATH for this python binary").
 
@@ -46,111 +43,124 @@ Try running:
 or 
 
  $ conda install -c etetoolkit ete3 ete_toolchain
-""")
-	sys.exit(1)
-
+"""
+    print(msg)
+    sys.exit(1)
 
 def get_args():
-	"""Parse command line arguments"""
-	import argparse
-    
-	try:
-		parser = argparse.ArgumentParser(description='Perform queries against the NCBI Taxa database. This script is still somewhat experimental.')
-		parser.add_argument('-v',
-				'--verbose',
-				action='count',
-				default=0,
-				help='Verbose behaviour. Supports 3 levels at present: Off = 0, Info = 1, Verbose = 2. [Def = 0]')
-		parser.add_argument('--update',
-				action='store_true',
-				help='Update the local taxon database before querying. Recommended if not used for a while. [Def = False]')
-		parser.add_argument('-t',
-				'--taxid',
-				action='store',
-				type=int,
-				help='The numerical TaxID to query. (e.g. 561)')
-		parser.add_argument('-n',
-				'--name',
-				action='store',
-				help='Provide a scientific name instead of a TaxID, if you\'re too lazy to find it out! (e.g. Escherichia).') 
-		parser.add_argument('-o',
-				'--outfile',
-				action='store',
-				help='Output file to store the descendent TaxIDs for the query.')
-		if len(sys.argv) == 1:
-			parser.print_help(sys.stderr)
-			sys.exit(1)
-	except:
-		print("An exception occurred with argument parsing. Check your provided options.")
-		sys.exit(1)
+    """Parse command line arguments
+    """
+    desc = 'Perform queries against the NCBI Taxa database'
+    epi = """DESCRIPTION:
+    This script lets you find out what TaxIDs to pass to ngd, and will write 
+    a simple one-item-per-line file to pass in to it. It utilises the ete3 
+    toolkit, so refer to their site to install the dependency if it's not 
+    already satisfied.
 
-	return parser.parse_args()
-
+    You can query the database using a particular TaxID, or a scientific name. 
+    The primary function of the script is to return all the child taxa of the
+    specified parent taxa. If specified with -v verbose flags however, the
+    script will also print out some information about the lineages etc.
+ 
+    WARNING: This script is still somewhat experimental
+    """
+    parser = argparse.ArgumentParser(description=desc, epilog=epi,
+                                     formatter_class=argparse.RawTextHelpFormatter)
+    parser.add_argument('taxid', metavar='taxid', type=str,
+			help='A comma-separated list of TaxIDs. (e.g. 561,2172)')   
+    parser.add_argument('-v', '--verbose', action='count', default=0,
+			help='Verbose behaviour. Supports 3 levels at present: Off = 0, Info = 1, Verbose = 2. (default: %(default)s)')
+    parser.add_argument('-d', '--database', type=str, default=None,
+			help='NCBI taxonomy database file path. If "None", it will be downloaded (default: %(default)s)')
+    parser.add_argument('-u', '--update', action='store_true', default=False,
+                        help='Update the local taxon database before querying. Recommended if not used for a while. (default: %(default)s)')
+    parser.add_argument('-j', '--just-taxids', action='store_true', default=False,
+                        help='Just write out a list of taxids an no other information (default: %(default)s)')
+    parser.add_argument('-i', '--taxon-info', action='store_true', default=False,
+                        help='Just write out rank & lineage info on the provided taxids (default: %(default)s)')
+    parser.add_argument('-n', '--name', action='store', help='Provide a scientific name instead of a TaxID, if you\'re too lazy to find it out! (e.g. Escherichia).') 
+    parser.add_argument('-o', '--outfile', action='store',
+			help='Output file to store the descendent TaxIDs for the query.')
+    return parser.parse_args()
 
 def pretty(d, indent=0):
-	"""A prettier way to print nested dicts"""
-	for key, value in d.items():
-		print('  ' * indent + str(key))
-		if isinstance(value, dict):
-			pretty(value, indent+1)
-		else:
-			print('  ' * (indent+1) + str(value))
+    """A prettier way to print nested dicts
+    """
+    for key, value in d.items():
+        print('  ' * indent + str(key))
+        if isinstance(value, dict):
+            pretty(value, indent+1)
+        else:
+            sys.stderr.write('  ' * (indent+1) + str(value) + '\n')
 
+def desc_taxa(taxid, ncbi, outFH, just_taxids=False):
+    """Write descendent taxa for taxid
+    """
+    # Main feature of the script is to get all taxa within a given group.	
+    descendent_taxa = ncbi.get_descendant_taxa(taxid)
+    descendent_taxa_names = ncbi.translate_to_names(descendent_taxa)
 
+    if just_taxids:
+        for taxid in descendent_taxa:
+            outFH.write(str(taxid) + '\n')
+    else:
+        for dtn, dt in zip(descendent_taxa_names, descendent_taxa):
+            x = [str(x) for x in [taxid, dt, dtn]]
+            outFH.write('\t'.join(x) + '\n')
+
+def taxon_info(taxid, ncbi, outFH):
+    """Write info on taxid
+    """
+    taxid = int(taxid)
+    tax_name = ncbi.get_taxid_translator([taxid])[taxid]
+    rank = list(ncbi.get_rank([taxid]).values())[0]
+    lineage = ncbi.get_taxid_translator(ncbi.get_lineage(taxid))
+    lineage = ['{}:{}'.format(k,v) for k,v in lineage.items()]
+    lineage = ';'.join(lineage)
+    x = [str(x) for x in [tax_name, taxid, rank, lineage]]
+    outFH.write('\t'.join(x) + '\n')
+            
 def main():
-	"""Make queries against NCBI Taxa databases"""
-	# Get commandline args		
-	args = get_args()
+    """Make queries against NCBI Taxa databases
+    """
+    # Get commandline args		
+    args = get_args()
 	
-	# Instantiate the ete NCBI taxa object
-	ncbi = NCBITaxa()
+    # Instantiate the ete NCBI taxa object
+    ncbi = NCBITaxa(dbfile=args.database)
+    ## dbfile location
+    if args.verbose > 1:
+        sys.stderr.write('Taxa database is stored at {}\n'.format(ncbi.dbfile))
 
-	if args.verbose > 1:
-		print("Taxa database is stored under ~/.etetoolkit/taxa.sqlite")
+    # Update the database if required.
+    if args.update is True:
+        if args.verbose > 1:
+            msg = 'Updating the taxonomy database. This may take several minutes...\n'
+            sys.stderr.write(msg)
+        ncbi.update_taxonomy_database()
+            
+    # If a name was provided instead of a TaxID, convert and store it.
+    if args.name:
+        args.taxid = [ncbi.get_name_translator([x])[x][0] for x in args.name.split(',')]
 
-	# Update the database if required.
-	if args.update is True:
-		if args.verbose > 1:
-			print("Updating the taxonomy database. This may take several minutes...")
-		ncbi.update_taxonomy_database()
-
-	# If a name was provided instead of a TaxID, convert and store it.
-	if args.name:
-		args.taxid = ncbi.get_name_translator([args.name])[args.name][0]
-	
-	if args.verbose > 0:
-		tax_dict = {}
-		# If a name was provided, simply add it to dict
-		if args.name:
-			tax_dict['Name'] = args.name
-		# If not, do the opposite conversion to the above and store that
-		else:
-                	tax_dict['Name'] = ncbi.get_taxid_translator([args.taxid])[args.taxid]
-                # Continue to populate the taxa dict with other information
-		tax_dict['TaxID'] = args.taxid
-		tax_dict['Rank'] = ncbi.get_rank([args.taxid])
-		tax_dict['Lineage'] = ncbi.get_taxid_translator(ncbi.get_lineage(args.taxid))
-
-
-		print("Information about your selected taxa:")
-		pretty(tax_dict)
-	
-	# Main feature of the script is to get all taxa within a given group.	
-	descendent_taxa = ncbi.get_descendant_taxa(args.taxid)
-	descendent_taxa_names = ncbi.translate_to_names(descendent_taxa)
-	print("Descendent taxa for TaxID: %s" % (args.taxid))
-
-	# Under python3, zip = izip. In python2, this list could be very large, and memory intensive
-	# Suggest the script is run with python3
-	if args.verbose > 0:
-		for dtn, dt in zip(descendent_taxa_names, descendent_taxa):
-			print("%s\t%s" % (dtn, dt))
-	
-	if args.outfile:
-		with open(args.outfile, 'w') as ofh:
-			for id in descendent_taxa:
-				ofh.write(str(id) + '\n')
-
+    # Output
+    if args.outfile is None:
+        outFH = sys.stdout
+    else:
+        outFH = open(args.outfile, 'w')
+        
+    for taxid in args.taxid.split(','):
+        if args.taxon_info:
+            outFH.write('\t'.join(['name', 'taxid', 'rank', 'lineage']) + '\n')
+            taxon_info(taxid, ncbi, outFH)
+        else:
+            if not args.just_taxids:
+                outFH.write('\t'.join(['parent_taxid',
+                                       'descendent_taxid',
+                                       'descendent_name']) + '\n')
+            desc_taxa(taxid, ncbi,  outFH, args.just_taxids)
+            
+    outFH.close()
 
 if __name__ == "__main__":
 	main()

--- a/contrib/gimme_taxa.py
+++ b/contrib/gimme_taxa.py
@@ -157,25 +157,28 @@ def main():
     # If names were provided in taxid list, convert to taxids
     args.taxid = args.taxid.replace('"', '').replace("'", '').split(',')
     args.taxid = name2taxid(args.taxid, ncbi)
-        
+
     # Output
     if args.outfile is None:
         outFH = sys.stdout
     else:
         outFH = open(args.outfile, 'w')
-        
+    ## header
+    if args.taxon_info:
+        outFH.write('\t'.join(['name', 'taxid', 'rank', 'lineage']) + '\n')
+    elif not args.just_taxids:
+        outFH.write('\t'.join(['parent_taxid',
+                               'descendent_taxid',
+                               'descendent_name']) + '\n')
+    ## body
     for taxid in args.taxid:
         if args.taxon_info:
-            outFH.write('\t'.join(['name', 'taxid', 'rank', 'lineage']) + '\n')
             taxon_info(taxid, ncbi, outFH)
         else:
-            if not args.just_taxids:
-                outFH.write('\t'.join(['parent_taxid',
-                                       'descendent_taxid',
-                                       'descendent_name']) + '\n')
             desc_taxa(taxid, ncbi,  outFH, args.just_taxids)
             
     outFH.close()
 
+    
 if __name__ == "__main__":
 	main()


### PR DESCRIPTION
When running `gimme_taxa.py`, I ran into some issues and features that I thought were missing. So, I wound up making some major changes to the script, which include:

* fixed bug: no taxid output if `-o` not provided. Output written to STDOUT if `-o` not specified
* the user can provide a database file name, so the database doesn't have to reside in the user's home directory (this can be bad in some situations)
* `taxid` is now a required variable. The user can provide a comma-sep list. The list can contain taxon names (removed the `--name` parameter)
* python2/3 compatibility updates
* reformatted and expanded UI
* reformatted the code to be more inline with PEP

The output is somewhat different, which could break some workflows, but I doubt it. If the user just wants a list of descendent taxids, this is still possible. I can update the readme for `ncbi-genome-download` if you'd like. 