### PR TITLE
add support for rm (repeat masked) eukaryotic genomes

### DIFF
--- a/ncbi_genome_download/config.py
+++ b/ncbi_genome_download/config.py
@@ -22,7 +22,7 @@ class NgdConfig(object):
     _FORMATS = OrderedDict([
         ('genbank', '_genomic.gbff.gz'),
         ('fasta', '_genomic.fna.gz'),
-		('rm', '_rm.out.gz'),
+        ('rm', '_rm.out.gz'),
         ('features', '_feature_table.txt.gz'),
         ('gff', '_genomic.gff.gz'),
         ('protein-fasta', '_protein.faa.gz'),

--- a/ncbi_genome_download/config.py
+++ b/ncbi_genome_download/config.py
@@ -28,6 +28,7 @@ class NgdConfig(object):
         ('genpept', '_protein.gpff.gz'),
         ('wgs', '_wgsmaster.gbff.gz'),
         ('cds-fasta', '_cds_from_genomic.fna.gz'),
+        ('rna-fna', '_rna.fna.gz'),
         ('rna-fasta', '_rna_from_genomic.fna.gz'),
         ('assembly-report', '_assembly_report.txt'),
         ('assembly-stats', '_assembly_stats.txt'),

--- a/ncbi_genome_download/config.py
+++ b/ncbi_genome_download/config.py
@@ -22,6 +22,7 @@ class NgdConfig(object):
     _FORMATS = OrderedDict([
         ('genbank', '_genomic.gbff.gz'),
         ('fasta', '_genomic.fna.gz'),
+		('rm', '_rm.out.gz'),
         ('features', '_feature_table.txt.gz'),
         ('gff', '_genomic.gff.gz'),
         ('protein-fasta', '_protein.faa.gz'),

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -685,6 +685,18 @@ def test_download_file_rna_fasta(req, tmpdir):
 
     assert core.worker(core.download_file_job(entry, str(dl_dir), checksums, 'rna-fasta'))
 
+def test_download_file_rna_fna(req, tmpdir):
+    entry = {'ftp_path': 'ftp://fake/path'}
+    fake_file = tmpdir.join('fake_rna.fna.gz')
+    fake_file.write('foo')
+    assert fake_file.check()
+    checksum = core.md5sum(str(fake_file))
+    checksums = [{'checksum': checksum, 'file': fake_file.basename}]
+    dl_dir = tmpdir.mkdir('download')
+    req.get('https://fake/path/fake_rna.fna.gz', text=fake_file.read())
+
+    assert core.worker(core.download_file_job(entry, str(dl_dir), checksums, 'rna-fna'))
+
 
 def test_download_file_symlink_path(req, tmpdir):
     entry = {'ftp_path': 'ftp://fake/path'}

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -685,6 +685,7 @@ def test_download_file_rna_fasta(req, tmpdir):
 
     assert core.worker(core.download_file_job(entry, str(dl_dir), checksums, 'rna-fasta'))
 
+
 def test_download_file_rna_fna(req, tmpdir):
     entry = {'ftp_path': 'ftp://fake/path'}
     fake_file = tmpdir.join('fake_rna.fna.gz')
@@ -696,6 +697,19 @@ def test_download_file_rna_fna(req, tmpdir):
     req.get('https://fake/path/fake_rna.fna.gz', text=fake_file.read())
 
     assert core.worker(core.download_file_job(entry, str(dl_dir), checksums, 'rna-fna'))
+
+
+def test_download_file_rm_out(req, tmpdir):
+    entry = {'ftp_path': 'ftp://fake/path'}
+    fake_file = tmpdir.join('fake_rm.out.gz')
+    fake_file.write('foo')
+    assert fake_file.check()
+    checksum = core.md5sum(str(fake_file))
+    checksums = [{'checksum': checksum, 'file': fake_file.basename}]
+    dl_dir = tmpdir.mkdir('download')
+    req.get('https://fake/path/fake_rm.out.gz', text=fake_file.read())
+
+    assert core.worker(core.download_file_job(entry, str(dl_dir), checksums, 'rm'))
 
 
 def test_download_file_symlink_path(req, tmpdir):


### PR DESCRIPTION
NCBI provides repeat masked files for eukaryotic genomes: `*_rm.out.gz`

From https://www.ncbi.nlm.nih.gov/genome/doc/ftpfaq/#masking

Repetitive sequences in eukaryotic genome assembly sequence files, as identified by WindowMasker, have been masked to lower-case.

The location and identity of repeats found by RepeatMasker are also provided in a separate file. These spans could be used to mask the genomic sequences if desired. Be aware, however, that many less studied organisms do not have good repeat libraries available for RepeatMasker to use.
