### PR TITLE
feat(core): add 'relation to type material' as as filtering option

### DIFF
--- a/ncbi_genome_download/config.py
+++ b/ncbi_genome_download/config.py
@@ -47,6 +47,14 @@ class NgdConfig(object):
         ('representative', 'representative genome'),
     ])
 
+    _RELATION_TO_TYPE_MATERIAL = OrderedDict([
+        ('type', 'assembly from type material'),
+        ('reference', 'assembly from reference material'),
+        ('synonym', 'assembly from synonym type material'),
+        ('proxytype', 'assembly from proxytype material'),
+        ('neotype', 'assembly designated as neotype')
+    ])
+
     _DEFAULTS = {
         'group': ['all'] + SUPPORTED_TAXONOMIC_GROUPS,
         'section': ['refseq', 'genbank'],
@@ -64,6 +72,7 @@ class NgdConfig(object):
         'metadata_table': None,
         'dry_run': False,
         'use_cache': False,
+        'type_material': ['any', 'all'] + list(_RELATION_TO_TYPE_MATERIAL)
     }
 
     _LIST_TYPES = set([
@@ -74,6 +83,7 @@ class NgdConfig(object):
         'genus',
         'species_taxid',
         'taxid',
+        'type_material'
     ])
 
     __slots__ = (
@@ -85,6 +95,7 @@ class NgdConfig(object):
         '_genus',
         '_species_taxid',
         '_taxid',
+        '_type_material',
         '_assembly_accessions',
         'output',
         'uri',
@@ -167,6 +178,23 @@ class NgdConfig(object):
         if 'all' in levels:
             levels = list(self._LEVELS)
         self._assembly_level = levels
+
+    @property
+    def type_material(self):
+        """Get the relation to type material. """
+        return self._type_material
+    @type_material.setter
+    def type_material(self, value):
+        type_materials = _create_list(value)
+        available_types = set(self._DEFAULTS['type_material'])
+        for type_material in type_materials:
+            if type_material not in available_types:
+                raise ValueError("Unsupported relation to type material: {}".format(type_material))
+        if 'all' in type_materials:
+            type_materials = list(self._RELATION_TO_TYPE_MATERIAL)
+        elif 'any' in type_materials:
+            type_materials = ['any']
+        self._type_material = type_materials
 
     @property
     def refseq_category(self):

--- a/ncbi_genome_download/core.py
+++ b/ncbi_genome_download/core.py
@@ -199,7 +199,7 @@ def config_download(config):
                 return 1
 
         if config.metadata_table:
-            with open(config.metadata_table, 'wt') as handle:
+            with codecs.open(config.metadata_table, mode='w', encoding='utf-8') as handle:
                 table = metadata.get()
                 table.write(handle)
 

--- a/ncbi_genome_download/core.py
+++ b/ncbi_genome_download/core.py
@@ -105,6 +105,13 @@ def argument_parser(version=None):
                         help='print debugging information')
     parser.add_argument('-V', '--version', action='version', version=version,
                         help='print version information')
+    parser.add_argument('-M', '--type-material', dest='type_material',
+                        default=NgdConfig.get_default('type_material'),
+                        help='Specifies the relation to type material for the assembly (default: %(default)s). '
+                        '"any" will include assemblies with no relation to type material value defined, "all" will download only assemblies with a defined value. '
+                        'A comma-separated list of relatons. For example: "reference,synonym".  '
+                        'Choose from: {choices} .  '.format(choices=NgdConfig.get_choices('type_material')))
+
     return parser
 
 
@@ -192,7 +199,7 @@ def config_download(config):
                 return 1
 
         if config.metadata_table:
-            with codecs.open(config.metadata_table, mode='w', encoding='utf-8') as handle:
+            with open(config.metadata_table, 'wt') as handle:
                 table = metadata.get()
                 table.write(handle)
 
@@ -238,6 +245,13 @@ def filter_entries(entries, config):
 
     new_entries = []
     for entry in entries:
+        if config.type_material and config.type_material != ['any']:
+            requested_types = map(lambda x: config._RELATION_TO_TYPE_MATERIAL[x], config.type_material)
+            if not entry['relation_to_type_material'] or entry['relation_to_type_material'] not in requested_types:
+                 logging.debug("Skipping assembly with no reference to type material or reference to type material does not match requested")
+                 continue 
+            else:
+                print(entry['relation_to_type_material'])
         if config.genus and not in_genus_list(entry['organism_name'], config.genus):
             logging.debug('Organism name %r does not start with any in %r, skipping',
                           entry['organism_name'], config.genus)

--- a/tests/test_arguments.py
+++ b/tests/test_arguments.py
@@ -82,5 +82,3 @@ def test_relation_to_type_material():
   parser = argument_parser()
   ns = parser.parse_args(args)
   assert ns.type_material == 'all'
-
-  #'type', 'reference', 'synonym', 'proxytype', 'neotype'

--- a/tests/test_arguments.py
+++ b/tests/test_arguments.py
@@ -54,3 +54,33 @@ def test_assembly_accessions():
     parser = argument_parser()
     ns = parser.parse_args(args=args)
     assert ns.assembly_accessions == 'some/path/here.txt'
+
+def test_relation_to_type_material():
+  """Test the -M/--type-material option works as expected."""
+  # Empty args should default to 'all'
+  args = ['bacteria']
+  parser = argument_parser()
+  ns = parser.parse_args(args)
+  assert ns.type_material == 'any'
+
+  args = ['-M', 'type', 'bacteria']
+  parser = argument_parser()
+  ns = parser.parse_args(args)
+  assert ns.type_material == 'type'
+
+  args = ['-M', 'type,synonym', 'fungi']
+  parser = argument_parser()
+  ns = parser.parse_args(args)
+  assert ns.type_material == 'type,synonym'
+
+  args = ['--type-material', 'reference', 'fungi']
+  parser = argument_parser()
+  ns = parser.parse_args(args)
+  assert ns.type_material == 'reference'
+
+  args = ['-M', 'all', 'fungi']
+  parser = argument_parser()
+  ns = parser.parse_args(args)
+  assert ns.type_material == 'all'
+
+  #'type', 'reference', 'synonym', 'proxytype', 'neotype'


### PR DESCRIPTION
We have a use case where we want to be able to filter bacterial/fungal assemblies based on the values in the 'relation to type material' metadata. This adds that ability while keeping the default behavior unchanged. 