### PR TITLE
relative symlinks instead of absolute symlinks

### DIFF
--- a/ncbi_genome_download/core.py
+++ b/ncbi_genome_download/core.py
@@ -540,12 +540,31 @@ def save_and_check(response, local_file, expected_checksum):
 
 
 def create_symlink(local_file, symlink_path):
-    """Create a symlink if symlink path is given."""
+    """Create a relative symbolic link if symlink path is given.
+
+    Parameters
+    ----------
+    local_file
+        relative path to output folder (includes ./ prefix) of file saved
+    symlink_path
+        relative path to output folder (includes ./ prefix) of symbolic link
+        to be created
+
+    Returns
+    -------
+    bool
+        success code
+
+    """
     if symlink_path is not None:
         if os.path.exists(symlink_path) or os.path.lexists(symlink_path):
             os.unlink(symlink_path)
-
-        os.symlink(os.path.abspath(local_file), symlink_path)
+        local_file = os.path.normpath(local_file)
+        symlink_path = os.path.normpath(symlink_path)
+        num_dirs_upward = len(os.path.dirname(symlink_path).split(os.sep))
+        local_relative_to_symlink = num_dirs_upward * (os.pardir + os.sep)
+        os.symlink(os.path.join(local_relative_to_symlink, local_file),
+            symlink_path)
 
     return True
 


### PR DESCRIPTION
`create_symlink` function was modified to make relative symbolic links (rather than absolute). This should resolve Issue #62

I tested these changes in Python 2.7.15 on Linux, but it should remain compatible with Mac and Windows.

**Here's what I used to test**
    Download
`ncbi-genome-download --species-taxid 36808 -H --format genbank -o ./ bacteria`
List path
`ls -lh ./human_readable/refseq/bacteria/Corynebacterium/bovis/F6900/GCF_003932215.1_ASM393221v1_genomic.gbff.gz`
Relative paths are printed as expected:
`./human_readable/refseq/bacteria/Corynebacterium/bovis/F6900/GCF_003932215.1_ASM393221v1_genomic.gbff.gz -> ../../../../../../refseq/bacteria/GCF_003932215.1/GCF_003932215.1_ASM393221v1_genomic.gbff.gz`
