### PR TITLE
core: remove print statement for type material

### DIFF
--- a/ncbi_genome_download/core.py
+++ b/ncbi_genome_download/core.py
@@ -256,8 +256,6 @@ def filter_entries(entries, config):
             if not entry['relation_to_type_material'] or entry['relation_to_type_material'] not in requested_types:
                 logging.debug("Skipping assembly with no reference to type material or reference to type material does not match requested")
                 continue
-            else:
-                print(entry['relation_to_type_material'])
         if config.genus and not in_genus_list(entry['organism_name'], config.genus):
             logging.debug('Organism name %r does not start with any in %r, skipping',
                           entry['organism_name'], config.genus)


### PR DESCRIPTION
This stray print statement produces a large number of unneeded writes to stdout, its removal would declutter terminal output and logs when used.
 
Example: 
```...
assembly from type material
assembly from type material
assembly from type material
assembly from type material
assembly from type material
assembly from type material
assembly from type material
assembly from type material
assembly from type material
assembly from type material
assembly from type material
assembly from type material
assembly from type material
assembly from type material
assembly from type material
assembly from type material
assembly from type material
assembly from type material
assembly from type material
assembly from type material
assembly from type material
assembly from type material
assembly from type material
assembly from type material
assembly from type material
assembly from type material
assembly from type material
assembly from type material
assembly from type material
assembly from type material
assembly from type material
assembly from type material
assembly from type material
assembly from type material
assembly from type material
...