### PR TITLE
Fill metadata table after the download jobs are created

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -147,11 +147,11 @@ def test_metadata_fill_multi(req, tmpdir):
     jobs = []
     assert len(core.metadata.get().rows) == 0
     download_candidates = [(entry, 'bacteria')]
-    with Pool(processes=1) as p:
-        for index, created_dl_job in enumerate(p.imap(core.downloadjob_creator_caller, [ (curr_entry, curr_group, config) for curr_entry, curr_group in download_candidates ])):
-            jobs.extend(created_dl_job)
-            assert download_candidates[index][0] == entry
-            core.fill_metadata(created_dl_job, download_candidates[index][0])
+    p = Pool(processes=1)
+    for index, created_dl_job in enumerate(p.imap(core.downloadjob_creator_caller, [ (curr_entry, curr_group, config) for curr_entry, curr_group in download_candidates ])):
+        jobs.extend(created_dl_job)
+        assert download_candidates[index][0] == entry
+        core.fill_metadata(created_dl_job, download_candidates[index][0])
     expected = [j for j in joblist if j.local_file.endswith('_genomic.gbff.gz')]
     assert len(core.metadata.get().rows) == 1
     assert jobs == expected


### PR DESCRIPTION
This is a suggestion that should fix #105 (and hopefully not introduce new bugs).

The initial problem is related to the use of a global variable with the python process pool. This PR changes when the metadata table gets filled, so that it is not done by a child process. 

commit 8afd93c adds 2 tests that mimic the DownloadJob making in both single processing and multi processing. The multi processing test is expected to fail.

commit 05103a5 introduces the changes I mentionned above.

commit bc6b498 modifies the tests so that they mimic the way things have changed.

While it seems to work, those changes feel a bit hacky, especially the tests which may not even have their place in test_core.py in the end since they test elements from both core.py and metadata.py, so feel free to delete the PR if they are inapropriate :smile: