### PR TITLE
made gimme_taxa.py an installable script

### DIFF
--- a/contrib/gimme_taxa.py
+++ b/contrib/gimme_taxa.py
@@ -32,18 +32,23 @@ import sys
 import argparse
 try:
     from ete3 import NCBITaxa
-except ImportError:
+except ImportError as exc:
+
+    # There are other reasons why this import may fail
+    # Thus make sure to print the import error as well.
     msg = """
 The ete3 import failed, the module doesn't appear to be installed
 (at least in the PYTHONPATH for this python binary").
 
 Try running:
- $ python -m pip install ete3
+ $ python -m pip install ete3 six
 
 or 
 
  $ conda install -c etetoolkit ete3 ete_toolchain
-"""
+ 
+Exception: %s
+""" % exc
     print(msg)
     sys.exit(1)
 

--- a/setup.py
+++ b/setup.py
@@ -82,4 +82,7 @@ setup(
     extras_require={
         'testing': tests_require,
     },
+    scripts=[
+        'contrib/gimme_taxa.py',
+    ],
 )


### PR DESCRIPTION
added `gimme_taxa.py` as an installable script,

clarified import error message, previously it would hide the actual import error and produce misleading directions