### PR TITLE
Na fix

### DIFF
--- a/ncbi_genome_download/core.py
+++ b/ncbi_genome_download/core.py
@@ -391,12 +391,12 @@ def create_downloadjob(entry, domain, config):
     """Create download jobs for all file formats from a summary file entry."""
     logger = logging.getLogger("ncbi-genome-download")
     logger.info('Checking record %r', entry['assembly_accession'])
-
     full_output_dir = create_dir(entry, config.section, domain, config.output, config.flat_output)
 
     symlink_path = None
     if config.human_readable:
         symlink_path = create_readable_dir(entry, config.section, domain, config.output)
+
     checksums = grab_checksums_file(entry)
 
     if not config.flat_output:

--- a/ncbi_genome_download/core.py
+++ b/ncbi_genome_download/core.py
@@ -193,6 +193,9 @@ def config_download(config):
         mtable = metadata.get()
         if config.parallel == 1:
             for entry, group in download_candidates:
+                if entry['ftp_path'] == "na":
+                    logger.warning("Entry %r has no ftp directory listed, skipping", entry['assembly_accession'])
+                    continue
                 curr_jobs = create_downloadjob(entry, group, config)
                 fill_metadata(curr_jobs, entry, mtable)
                 download_jobs.extend(curr_jobs)
@@ -388,12 +391,12 @@ def create_downloadjob(entry, domain, config):
     """Create download jobs for all file formats from a summary file entry."""
     logger = logging.getLogger("ncbi-genome-download")
     logger.info('Checking record %r', entry['assembly_accession'])
+
     full_output_dir = create_dir(entry, config.section, domain, config.output, config.flat_output)
 
     symlink_path = None
     if config.human_readable:
         symlink_path = create_readable_dir(entry, config.section, domain, config.output)
-
     checksums = grab_checksums_file(entry)
 
     if not config.flat_output:


### PR DESCRIPTION
The downloader currently ungracefully terminates if no ftp directory is listed for an entry. This is for example the case in this entry:

Executing 
```
ncbi-genome-download -s genbank -t 104688   -v -d invertebrate
```
The corresponding entries for this taxa are:
```bash
$ grep 104688 genbank_invertebrate_assembly_summary.txt
GCA_001014625.1	PRJNA268391	SAMN03283234	JXPT00000000.1	na	104688	104688	Bactrocera oleae		BV_Boleae	latest	Scaffold	Major	Full	2015/05/28	ASM101462v1	UC Berkeley	na	na	ftp://ftp.ncbi.nlm.nih.gov/genomes/all/GCA/001/014/625/GCA_001014625.1_ASM101462v1		
GCA_001188975.4	PRJNA288990	SAMN03840585	LGAM00000000.2	representative genome	104688	104688	Bactrocera oleae		Demokritus	latest	Scaffold	Major	Full	2019/04/30	MU_Boleae_v2	McGill University	na	na	na
```

Will result in a crash. I assume this is a mistake in the genbank file, but still should not result in a crash.

I suggest skipping entries with no FTP directory in order to still successfully download the remaining genomes. I think this is a reasonable behaviour as these entries do not seem to have data attached to them.
