### PR TITLE
Check if the ftp directory listed is NA when filtering

### DIFF
--- a/ncbi_genome_download/core.py
+++ b/ncbi_genome_download/core.py
@@ -320,6 +320,10 @@ def filter_entries(entries, config):
             logger.debug('Skipping entry with refseq_category %r, not %r', entry['refseq_category'],
                           config.refseq_category)
             continue
+        if entry['ftp_path'] == "na":
+            logger.warning("Skipping entry, as it has no ftp directory listed: %r", entry['assembly_accession'])
+            continue
+
         new_entries.append(entry)
 
     return new_entries


### PR DESCRIPTION
The downloader currently ungracefully terminates if no ftp directory is listed for an entry. This is for example the case in this entry:

Executing
```
ncbi-genome-download -s genbank -t 104688   -v -d invertebrate
```
The corresponding entries for this taxa are:
```
$ grep 104688 genbank_invertebrate_assembly_summary.txt
GCA_001014625.1	PRJNA268391	SAMN03283234	JXPT00000000.1	na	104688	104688	Bactrocera oleae		BV_Boleae	latest	Scaffold	Major	Full	2015/05/28	ASM101462v1	UC Berkeley	na	na	ftp://ftp.ncbi.nlm.nih.gov/genomes/all/GCA/001/014/625/GCA_001014625.1_ASM101462v1		
GCA_001188975.4	PRJNA288990	SAMN03840585	LGAM00000000.2	representative genome	104688	104688	Bactrocera oleae		Demokritus	latest	Scaffold	Major	Full	2019/04/30	MU_Boleae_v2	McGill University	na	na	na
```
Will result in a crash. I assume this is a mistake in the genbank file, but still should not result in a crash.

I suggest skipping entries with no FTP directory in order to still successfully download the remaining genomes. I think this is a reasonable behaviour as these entries do not seem to have data attached to them.

The fix suggested here will result in warning messages like: 
```
WARNING: Skipping entry, as it has no ftp directory listed: u'GCA_011090175.1
```
Currently this is an issue for 5 genomes in genbank bacteria for example.

This pull request replaces https://github.com/kblin/ncbi-genome-download/pull/113
