### PR TITLE
raise warning if refseq metagenome is requested

### DIFF
--- a/ncbi_genome_download/config.py
+++ b/ncbi_genome_download/config.py
@@ -1,5 +1,4 @@
 """Configuration for the downloader."""
-
 import codecs
 from collections import OrderedDict
 import os
@@ -17,6 +16,10 @@ SUPPORTED_TAXONOMIC_GROUPS = [
     'vertebrate_other',
     'viral'
 ]
+
+GENBANK_EXCLUSIVE = [
+        'metagenomes'
+        ]
 
 
 # TODO: Remove this once we drop py2 support
@@ -154,6 +157,10 @@ class NgdConfig(object):
         for group in groups:
             if group not in available_groups:
                 raise ValueError("Unsupported group: {}".format(group))
+            # in a first initialisation 'section' might not be set
+            if hasattr(self, 'section'):
+                if self.section == "refseq" and group in GENBANK_EXCLUSIVE:
+                    raise ValueError("Unsupported group in refseq: {}".format(group))
 
         if 'all' in groups:
             groups = SUPPORTED_TAXONOMIC_GROUPS


### PR DESCRIPTION
This pull request addresses the issue https://github.com/kblin/ncbi-genome-download/issues/115
While I find it not very elegant to check if 'section' is already set, this was the only way I could cross reference section as well as group in one go.
If a better solution can be found, this would be nice, but for now this seems to work well.