### PR TITLE
Removing zombie processes

### DIFF
--- a/ncbi_genome_download/core.py
+++ b/ncbi_genome_download/core.py
@@ -202,7 +202,11 @@ def config_download(config):
         else:  # pragma: no cover
             # Testing multiprocessing code is annoying
             with Pool(processes=config.parallel) as pool:
-                for index, created_dl_job in enumerate(pool.imap(downloadjob_creator_caller, [ (entry, group, config) for entry, group in download_candidates ])):
+                dl_jobs = pool.imap(
+                        downloadjob_creator_caller,
+                        [ (entry, group, config) for entry, group in download_candidates ],
+                    )
+                for index, created_dl_job in enumerate(dl_jobs):
                     download_jobs.extend(created_dl_job)
                     # index is conserved from download_candidates with the use of imap
                     fill_metadata(created_dl_job, download_candidates[index][0], mtable)


### PR DESCRIPTION
This should address at least part of Issue #120. A minimal example that demonstrates the need of this is:

``` Python 3
from ncbi_genome_download import download as ngd

for i in range(100):
	print(i)
	ngd( parallel=9, group="viral", genus="Enterococcus phage", fuzzy_genus=True )
```

Without the proposed change, this creates hanging processes with every iteration that quickly litter the memory. The reason for this is elaborated in the big red warning in the [`multiprocess` documentation](https://docs.python.org/3/library/multiprocessing.html#module-multiprocessing.pool):

> `multiprocessing.pool` objects have internal resources that need to be properly managed (like any other resource) by using the pool as a context manager or […]. Failure to do this can lead to the process hanging on finalization.